### PR TITLE
Add realtime view page

### DIFF
--- a/app/Events/ApproveSent.php
+++ b/app/Events/ApproveSent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ApproveSent implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $group;
+    public $requester;
+    public $approver;
+
+    public function __construct(User $requester, User $approver, Group $group)
+    {
+        $this->requester = $requester;
+        $this->approver = $approver;
+        $this->group = $group;
+    }
+
+    public function broadcastOn()
+    {
+        return new PresenceChannel('group-chat.' . $this->group->id);
+    }
+}

--- a/app/Events/RequestSent.php
+++ b/app/Events/RequestSent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class RequestSent implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $group;
+    public $requester;
+
+    public function __construct(User $requester, Group $group)
+    {
+        $this->requester = $requester;
+        $this->group = $group;
+    }
+
+    public function broadcastOn()
+    {
+        return new PresenceChannel('group-chat.' . $this->group->id);
+    }
+}

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -9,17 +9,37 @@ use App\Models\Message;
 use App\Models\Movie;
 use App\Models\Platform;
 use App\Models\User;
+use App\Models\ViewGroup;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use App\Events\MessageSent;
+use App\Events\RequestSent;
+use App\Events\ApproveSent;
+
 
 class ChatController extends Controller
 {
     public function index($groupId)
     {
         $group = Group::findOrFail($groupId);
-        return view('chat.index', compact('group'));
+        $movies = Movie::all();
+        $viewGroups = ViewGroup::where('group_id', $groupId)->get();
+        
+        foreach ($viewGroups as $viewGroup) {
+            // ユーザーが申請者であるかどうかをチェック
+            $isRequester = Auth::user()->id == $viewGroup->requester_id;
+        
+            // ユーザーがすでに承認者であるかどうかをチェック
+            $hasApproved = $viewGroup->approvers()->where('user_id', Auth::user()->id)->exists();
+            
+            // チェック結果を各viewGroupオブジェクトに追加
+            $viewGroup->is_requester = $isRequester;
+            $viewGroup->has_approved = $hasApproved;
+        }
+
+
+        return view('chat.index', compact('group', 'viewGroups', 'movies'));
     }
     
     public function sent(Request $request, $groupId)
@@ -40,5 +60,82 @@ class ChatController extends Controller
         event(new MessageSent($chatMessage)); // メッセージ送信イベントを発行
     
         return redirect()->back();
+    }
+    
+    public function request(Request $request, $groupId)
+    {
+        $user = $request->user();
+        $group = Group::findOrFail($groupId);
+        $movieId = $request->input('movie_id');
+        $movie = Movie::findOrFail($movieId);
+
+        $viewGroup = new ViewGroup();
+        $viewGroup->group()->associate($group);
+        $viewGroup->requester()->associate($user);
+        $viewGroup->movie()->associate($movie);
+        $viewGroup->start_time = $request->input('start_time');
+        $viewGroup->save();
+        $viewGroupId = $viewGroup->id;
+        $viewGroup->view_link = url("/moviechat/group/$groupId/view/$viewGroupId");
+        $viewGroup->save();
+
+        return redirect()->back();
+    }
+
+    public function approve(Request $request, $groupId, $viewGroupId)
+    {
+        $user = $request->user();
+        $viewGroup = ViewGroup::findOrFail($viewGroupId);
+        $viewGroup->approvers()->attach($user);
+
+        return redirect()->back();
+    }
+    
+    public function view($groupId, $viewGroupId)
+    {
+        $viewGroup = ViewGroup::findOrFail($viewGroupId);
+        
+        $group = Group::findOrFail($groupId);
+
+        return view('chat.view', compact('group', 'viewGroup'));
+    }
+    
+    public function viewChat(Request $request, $groupId, $viewGroupId)
+    {
+        $validator = Validator::make($request->all(), [
+            'message' => 'required|max:20',
+        ]);
+    
+        $user = $request->user();
+        $viewGroup = ViewGroup::findOrFail($viewGroupId);
+    
+        $chatMessage = new Message();
+        $chatMessage->content = $request->input('message');
+        $chatMessage->user()->associate($user);
+        $chatMessage->viewGroup()->associate($viewGroup);
+        $chatMessage->save();
+    
+        return redirect()->back();
+    }
+    
+    public function cancel($groupId, $viewGroupId)
+    {
+        $viewGroup = ViewGroup::findOrFail($viewGroupId);
+    
+        // ユーザーが申請者である場合のみ申請を取り消すことができます
+        if (Auth::user()->id == $viewGroup->requester_id) {
+            $viewGroup->delete();
+        }
+    
+        return redirect()->back();
+    }
+    
+    // ユーザーがグループから脱退するメソッド
+    public function leaveGroup($groupId)
+    {
+        $group = Group::findOrFail($groupId);
+        $group->users()->detach(Auth::user()->id);
+    
+        return redirect()->route('group.myList');
     }
 }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -95,7 +95,7 @@ class GroupController extends Controller
         
         // 成功時の処理
         $groups = $this->getGroupWithMember();
-        return view('groups.list', compact('groups'));
+        return redirect()->route('group.myList');
     }
     
     public function joinGroup($groupId)

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -53,4 +53,9 @@ class Group extends Model
     {
         return $this->hasMany(Message::class);
     }
+    
+    public function viewGroups()
+    {
+        return $this->hasMany(ViewGroup::class);
+    }
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -16,6 +16,7 @@ class Message extends Model
     protected $fillable = [
         'group_id',
         'user_id',
+        'view_group_id',
         'content',
     ];
 
@@ -27,5 +28,10 @@ class Message extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+    
+    public function viewGroup()
+    {
+        return $this->belongsTo(ViewGroup::class);
     }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -24,6 +24,11 @@ class Movie extends Model
         return $this->belongsToMany(Group::class);
     }
     
+    public function viewGroups()
+    {
+        return $this->hasMany(ViewGroup::class);
+    }
+    
     public function genres()
     {
         return $this->belongsToMany(Genre::class, 'movie_genre');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,11 @@ class User extends Authenticatable
         return $this->belongsToMany(Group::class);
     }
     
+    public function viewApprovers()
+    {
+        return $this->belongsToMany(ViewGroup::class, 'view_approvers');
+    }
+    
     public function messages()
     {
         return $this->hasMany(Message::class);
@@ -54,6 +59,13 @@ class User extends Authenticatable
     
     public function creators()
     {
-        return $this->hasMany(Group::class, 'created_id');
+        return $this->hasMany(Group::class);
     }
+    
+    public function requesters()
+    {
+        return $this->hasMany(ViewGroup::class);
+    }
+    
+    
 }

--- a/app/Models/ViewGroup.php
+++ b/app/Models/ViewGroup.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ViewGroup extends Model
+{
+    use HasFactory;
+    
+    protected $table = 'view_groups';
+    protected $primaryKey = 'id';
+    public $timestamps = true;
+
+    protected $fillable = [
+        'group_id',
+        'requester_id',
+        'movie_id',
+        'view_link',
+        'start_time',
+    ];
+
+    public function group()
+    {
+        return $this->belongsTo(Group::class);
+    }
+    
+    public function requester()
+    {
+        return $this->belongsTo(User::class);
+    }
+    
+    public function movie()
+    {
+        return $this->belongsTo(Movie::class);
+    }
+    
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+    
+    public function approvers()
+    {
+        return $this->belongsToMany(User::class, 'view_approvers');
+    }
+}

--- a/database/migrations/2023_07_06_131400_create_view_groups_table.php
+++ b/database/migrations/2023_07_06_131400_create_view_groups_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('view_groups', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('group_id')->nullable();
+            $table->unsignedBigInteger('requester_id')->nullable();
+            $table->unsignedBigInteger('movie_id')->nullable();
+            $table->string('view_link')->nullable();
+            $table->timestamp('start_time');
+            $table->timestamps();
+            
+            $table->foreign('group_id')->references('id')->on('groups')->onDelete('set null');
+            $table->foreign('requester_id')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('movie_id')->references('id')->on('movies')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('view_groups');
+    }
+};

--- a/database/migrations/2023_07_06_131431_create_view_approvers_table.php
+++ b/database/migrations/2023_07_06_131431_create_view_approvers_table.php
@@ -13,18 +13,15 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('messages', function (Blueprint $table) {
+        Schema::create('view_approvers', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('group_id');
-            $table->unsignedBigInteger('user_id')->nullable();
-            $table->text('content');
-            $table->timestamps();
-        
-            $table->foreign('group_id')->references('id')->on('groups')->onDelete('cascade');
+            $table->unsignedBigInteger('view_group_id');
+            $table->unsignedBigInteger('user_id');
+            
+            $table->foreign('view_group_id')->references('id')->on('view_groups')->onDelete('cascade');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
-
 
     /**
      * Reverse the migrations.
@@ -33,6 +30,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('messages');
+        Schema::dropIfExists('view_approvers');
     }
 };

--- a/database/migrations/2023_07_06_144543_create_messages_table.php
+++ b/database/migrations/2023_07_06_144543_create_messages_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('group_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->unsignedBigInteger('view_group_id')->nullable();
+            $table->text('content');
+            $table->timestamps();
+        
+            $table->foreign('group_id')->references('id')->on('groups')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('view_group_id')->references('id')->on('view_groups')->onDelete('cascade');
+        });
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -21,36 +21,76 @@
                         <p>・{{ $member->name }}</p>
                     @endforeach
                 </p>
-                
-                
-                
+        
                 <div id="chat-messages">
                     @foreach ($group->messages as $message)
                         <p>{{ $message->user->name }}: {{ $message->content }}: {{ $message->created_at }}</p>
                     @endforeach
                 </div>
-                
+        
+                <form action="/moviechat/group/{{ $group->id }}/request" method="POST">
+                    @csrf
+                    <label for="movie-title">映画タイトル</label>
+                    <select name="movie_id" required>
+                        <option value="">映画タイトルを選択してください</option>
+                        @foreach ($movies as $movie)
+                            <option value="{{ $movie->id }}">{{ $movie->title }}</option>
+                        @endforeach
+                    </select>
+                    <label for="start-time">視聴開始時間</label>
+                    <input type="datetime-local" id="start_time" name='start_time' required>
+                    <button type="submit">同時視聴申請</button>
+                </form>
+
+                <div id="view-requests">
+                    @foreach ($viewGroups as $viewGroup)
+                        <p>{{ $viewGroup->requester->name }}が同時視聴を希望しています</p>
+                        @if(!$viewGroup->has_approved && !$viewGroup->is_requester)
+                            <form action="/moviechat/group/{{ $group->id }}/approve/{{ $viewGroup->id }}" method="POST">
+                                @csrf
+                                <button type="submit">同意する</button>
+                            </form>
+                        @endif
+                        @if($viewGroup->approvers->contains(Auth::id()))
+                            @foreach ($viewGroup->approvers as $approver)
+                                <p>{{ $approver->name }}が{{ $viewGroup->requester->name }}の同時視聴を承認しています</p>
+                            @endforeach
+                            <p>視聴URL: <a href="{{ $viewGroup->view_link }}">同時視聴用チャット先リンク</a></p>
+                        @endif
+                        @if($viewGroup->is_requester)
+                            <form method="POST" action="{{ route('view.cancel', ['groupId' => $group->id, 'viewGroupId' => $viewGroup->id]) }}">
+                                @csrf
+                                <button type="submit">申請取り消し</button>
+                            </form>
+                        @endif
+                    @endforeach
+                </div>
+
+        
                 <script src="https://js.pusher.com/7.0/pusher.min.js"></script>
                 <script>
                     window.Pusher = new Pusher('{{ env("PUSHER_APP_KEY") }}', {
                         cluster: '{{ env("PUSHER_APP_CLUSTER") }}',
                         forceTLS: true
                     });
+        
                     var channel = window.Pusher.subscribe('group-chat.{{ $group->id }}');
+        
                     channel.bind('.message.sent', function(data) {
                         const chatMessages = document.getElementById('chat-messages');
                         const message = document.createElement('p');
-                        message.innerText = ': ' + data.message.content + ': ' + data.message.created_at;
+                        message.innerText = data.message.user.name + ': ' + data.message.content + ': ' + data.message.created_at;
                         chatMessages.appendChild(message);
                     });
                 </script>
-                                
+        
                 <form action="/moviechat/group/{{ $group->id }}/chat" method="POST">
                     @csrf
-                    <input type="text" name="message" placeholder="メッセージを入力" required maxlength="20">
+                    <input type="text" name="message" placeholder="メッセージを入力">
                     <button type="submit">送信</button>
                 </form>
                 
+                <button onclick="location.href='{{ route('group.leave', $group->id) }}'">グループを退会する</button>
             </div>
         </x-app-layout>
     </body>

--- a/resources/views/chat/view.blade.php
+++ b/resources/views/chat/view.blade.php
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <title>MovieChat</title>
+        <!-- Fonts -->
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+    </head>
+    <body>
+        <x-app-layout>
+            <x-slot name="header">
+                <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                    Chat
+                </h2>
+            </x-slot>
+            
+            <div>
+                <p>映画：{{ $viewGroup->movie->title }}</p>
+                <p>視聴者：
+                    {{ $viewGroup->requester->name }}
+                    @foreach ($viewGroup->approvers as $member)
+                        <p>・{{ $member->name }}</p>
+                    @endforeach
+                </p>
+                
+                <div id="chat-messages">
+                    @foreach ($viewGroup->messages as $message)
+                        <p>{{ $message->user->name }}: {{ $message->content }}: {{ $message->created_at }}</p>
+                    @endforeach
+                </div>
+                                
+                <form action="/moviechat/group/{{ $group->id }}/view/{{ $viewGroup->id }}" method="POST">
+                    @csrf
+                    <input type="text" name="message" placeholder="メッセージを入力" required maxlength="20">
+                    <button type="submit">送信</button>
+                </form>
+                
+            </div>
+        </x-app-layout>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,7 +49,14 @@ Route::middleware(['auth'])->group(function () {
             Route::delete('/{groupId}', [GroupController::class, 'destroy'])->name('group.destroy');
             
             Route::get('/{groupId}/chat', [ChatController::class, 'index'])->name('chat.index');
-            Route::post('{groupId}/chat', [ChatController::class, 'sent'])->name('chat.sent');
+            Route::post('/{groupId}/chat', [ChatController::class, 'sent'])->name('chat.sent');
+            Route::get('/{groupId}/leave', [ChatController::class, 'leaveGroup'])->name('group.leave');
+            Route::post('/{groupId}/request', [ChatController::class, 'request'])->name('view.request');
+            Route::post('/{groupId}/approve/{viewGroupId}', [ChatController::class, 'approve'])->name('view.approve');
+            Route::post('/{groupId}/cancel/{viewGroupId}', [ChatController::class, 'cancel'])->name('view.cancel');
+            Route::get('/{groupId}/view/{viewGroupId}', [ChatController::class, 'view'])->name('view.index');
+            Route::post('/{groupId}/view/{viewGroupId}', [ChatController::class, 'viewChat'])->name('view.chat');
+            
         });
         
         Route::prefix('movie')->group(function () {


### PR DESCRIPTION
同時視聴ページの作成
グループチャットで同時視聴の申請と同意を行えるようにした。
同意が得られたらリンク先を表示させた。
申請・同意用に新たにview_groupsのテーブルを作成した。
申請消去・グループ退会も加えた。
同時視聴ページのチャットとグループのチャットは別々で行えるようにした。